### PR TITLE
Add run command for docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ services:
   adguardhome-sync:
     image: ghcr.io/bakito/adguardhome-sync
     container_name: adguardhome-sync
+    command: run --config /config/adguardhome-sync.yaml
     volumes:
       - /path/to/appdata/config/adguardhome-sync.yaml:/config/adguardhome-sync.yaml
     ports:


### PR DESCRIPTION
I didn't manage to get it working with your example. I figured out that this is working fine. I noticed the other example did already contain the `run` command.

And thanks a lot for this tool!