### PR TITLE
Fix API change and block inconsistent version v0.107.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ endif
 
 start-replica:
 	podman run --pull always --rm -it -p 9090:80 -p 9091:3000  adguard/adguardhome
+#	podman run --pull always --rm -it -p 9090:80 -p 9091:3000  adguard/adguardhome:v0.107.13
 
 check_defined = \
     $(strip $(foreach 1,$1, \

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bakito/adguardhome-sync/pkg/log"
 	"github.com/bakito/adguardhome-sync/pkg/types"
+	"github.com/bakito/adguardhome-sync/pkg/versions"
 	"github.com/go-resty/resty/v2"
 	"go.uber.org/zap"
 )
@@ -120,9 +121,10 @@ type Client interface {
 }
 
 type client struct {
-	client *resty.Client
-	log    *zap.SugaredLogger
-	host   string
+	client  *resty.Client
+	log     *zap.SugaredLogger
+	host    string
+	version string
 }
 
 func (cl *client) Host() string {
@@ -174,6 +176,7 @@ func (cl *client) doPost(req *resty.Request, url string) error {
 func (cl *client) Status() (*types.Status, error) {
 	status := &types.Status{}
 	err := cl.doGet(cl.client.R().EnableTrace().SetResult(status), "status")
+	cl.version = status.Version
 	return status, err
 }
 
@@ -302,7 +305,14 @@ func (cl *client) ToggleProtection(enable bool) error {
 
 func (cl *client) SetCustomRules(rules types.UserRules) error {
 	cl.log.With("rules", len(rules)).Info("Set user rules")
-	return cl.doPost(cl.client.R().EnableTrace().SetBody(rules.String()), "/filtering/set_rules")
+
+	var payload interface{}
+	if versions.IsNewerThan(cl.version, versions.LastStringCustomRules) {
+		payload = &types.UserRulesRequest{Rules: rules}
+	} else {
+		payload = rules.String()
+	}
+	return cl.doPost(cl.client.R().EnableTrace().SetBody(payload), "/filtering/set_rules")
 }
 
 func (cl *client) ToggleFiltering(enabled bool, interval float64) error {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/bakito/adguardhome-sync/pkg/log"
 	"github.com/bakito/adguardhome-sync/pkg/types"
-	"github.com/bakito/adguardhome-sync/pkg/versions"
 	"github.com/go-resty/resty/v2"
 	"go.uber.org/zap"
 )
@@ -305,14 +304,7 @@ func (cl *client) ToggleProtection(enable bool) error {
 
 func (cl *client) SetCustomRules(rules types.UserRules) error {
 	cl.log.With("rules", len(rules)).Info("Set user rules")
-
-	var payload interface{}
-	if versions.IsNewerThan(cl.version, versions.LastStringCustomRules) {
-		payload = &types.UserRulesRequest{Rules: rules}
-	} else {
-		payload = rules.String()
-	}
-	return cl.doPost(cl.client.R().EnableTrace().SetBody(payload), "/filtering/set_rules")
+	return cl.doPost(cl.client.R().EnableTrace().SetBody(rules.ToPayload(cl.version)), "/filtering/set_rules")
 }
 
 func (cl *client) ToggleFiltering(enabled bool, interval float64) error {

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -8,13 +8,11 @@ import (
 	"github.com/bakito/adguardhome-sync/pkg/client"
 	"github.com/bakito/adguardhome-sync/pkg/log"
 	"github.com/bakito/adguardhome-sync/pkg/types"
+	"github.com/bakito/adguardhome-sync/pkg/versions"
 	"github.com/bakito/adguardhome-sync/version"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/zap"
-	"golang.org/x/mod/semver"
 )
-
-const minAghVersion = "v0.107.0"
 
 var l = log.GetLogger("sync")
 
@@ -107,8 +105,8 @@ func (w *worker) sync() {
 		return
 	}
 
-	if semver.Compare(o.status.Version, minAghVersion) == -1 {
-		sl.With("error", err, "version", o.status.Version).Errorf("Origin AdGuard Home version must be >= %s", minAghVersion)
+	if !versions.IsNewerThan(o.status.Version, versions.MinAgh) {
+		sl.With("error", err, "version", o.status.Version).Errorf("Origin AdGuard Home version must be >= %s", versions.MinAgh)
 		return
 	}
 
@@ -205,8 +203,8 @@ func (w *worker) syncTo(l *zap.SugaredLogger, o *origin, replica types.AdGuardIn
 
 	rl.With("version", o.status.Version).Info("Connected to replica")
 
-	if semver.Compare(rs.Version, minAghVersion) == -1 {
-		rl.With("error", err, "version", rs.Version).Errorf("Replica AdGuard Home version must be >= %s", minAghVersion)
+	if !versions.IsNewerThan(rs.Version, versions.MinAgh) {
+		rl.With("error", err, "version", rs.Version).Errorf("Replica AdGuard Home version must be >= %s", versions.MinAgh)
 		return
 	}
 

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -208,6 +208,11 @@ func (w *worker) syncTo(l *zap.SugaredLogger, o *origin, replica types.AdGuardIn
 		return
 	}
 
+	if versions.IsSame(rs.Version, versions.IncompatibleAPI) {
+		rl.With("error", err, "version", rs.Version).Errorf("Replica AdGuard Home runs with an incompatible API - Please ugrade to version %s or newer", versions.FixedIncompatibleAPI)
+		return
+	}
+
 	if o.status.Version != rs.Version {
 		rl.With("originVersion", o.status.Version, "replicaVersion", rs.Version).Warn("Versions do not match")
 	}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -105,7 +105,7 @@ func (w *worker) sync() {
 		return
 	}
 
-	if !versions.IsNewerThan(o.status.Version, versions.MinAgh) {
+	if versions.IsNewerThan(versions.MinAgh, o.status.Version) {
 		sl.With("error", err, "version", o.status.Version).Errorf("Origin AdGuard Home version must be >= %s", versions.MinAgh)
 		return
 	}
@@ -203,7 +203,7 @@ func (w *worker) syncTo(l *zap.SugaredLogger, o *origin, replica types.AdGuardIn
 
 	rl.With("version", o.status.Version).Info("Connected to replica")
 
-	if !versions.IsNewerThan(rs.Version, versions.MinAgh) {
+	if versions.IsNewerThan(versions.MinAgh, rs.Version) {
 		rl.With("error", err, "version", rs.Version).Errorf("Replica AdGuard Home version must be >= %s", versions.MinAgh)
 		return
 	}

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bakito/adguardhome-sync/pkg/client"
 	clientmock "github.com/bakito/adguardhome-sync/pkg/mocks/client"
 	"github.com/bakito/adguardhome-sync/pkg/types"
+	"github.com/bakito/adguardhome-sync/pkg/versions"
 	gm "github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -483,7 +484,7 @@ var _ = Describe("Sync", func() {
 			It("should have no changes", func() {
 				// origin
 				cl.EXPECT().Host()
-				cl.EXPECT().Status().Return(&types.Status{Version: minAghVersion}, nil)
+				cl.EXPECT().Status().Return(&types.Status{Version: versions.MinAgh}, nil)
 				cl.EXPECT().Parental()
 				cl.EXPECT().SafeSearch()
 				cl.EXPECT().SafeBrowsing()
@@ -499,7 +500,7 @@ var _ = Describe("Sync", func() {
 
 				// replica
 				cl.EXPECT().Host()
-				cl.EXPECT().Status().Return(&types.Status{Version: minAghVersion}, nil)
+				cl.EXPECT().Status().Return(&types.Status{Version: versions.MinAgh}, nil)
 				cl.EXPECT().Parental()
 				cl.EXPECT().SafeSearch()
 				cl.EXPECT().SafeBrowsing()
@@ -536,7 +537,7 @@ var _ = Describe("Sync", func() {
 			It("replica version is too small", func() {
 				// origin
 				cl.EXPECT().Host()
-				cl.EXPECT().Status().Return(&types.Status{Version: minAghVersion}, nil)
+				cl.EXPECT().Status().Return(&types.Status{Version: versions.MinAgh}, nil)
 				cl.EXPECT().Parental()
 				cl.EXPECT().SafeSearch()
 				cl.EXPECT().SafeBrowsing()

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -556,6 +556,28 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().Status().Return(&types.Status{Version: "v0.106.9"}, nil)
 				w.sync()
 			})
+			It("replica version is with incompatible API", func() {
+				// origin
+				cl.EXPECT().Host()
+				cl.EXPECT().Status().Return(&types.Status{Version: versions.MinAgh}, nil)
+				cl.EXPECT().Parental()
+				cl.EXPECT().SafeSearch()
+				cl.EXPECT().SafeBrowsing()
+				cl.EXPECT().RewriteList().Return(&types.RewriteEntries{}, nil)
+				cl.EXPECT().Services()
+				cl.EXPECT().Filtering().Return(&types.FilteringStatus{}, nil)
+				cl.EXPECT().Clients().Return(&types.Clients{}, nil)
+				cl.EXPECT().QueryLogConfig().Return(&types.QueryLogConfig{}, nil)
+				cl.EXPECT().StatsConfig().Return(&types.IntervalConfig{}, nil)
+				cl.EXPECT().AccessList().Return(&types.AccessList{}, nil)
+				cl.EXPECT().DNSConfig().Return(&types.DNSConfig{}, nil)
+				cl.EXPECT().DHCPServerConfig().Return(&types.DHCPServerConfig{}, nil)
+
+				// replica
+				cl.EXPECT().Host()
+				cl.EXPECT().Status().Return(&types.Status{Version: versions.IncompatibleAPI}, nil)
+				w.sync()
+			})
 		})
 	})
 })

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/bakito/adguardhome-sync/pkg/versions"
 )
 
 const (
@@ -208,6 +210,14 @@ type UserRules []string
 // String toString of Users
 func (ur UserRules) String() string {
 	return strings.Join(ur, "\n")
+}
+
+// ToPayload return the version specific payload for user rules
+func (ur UserRules) ToPayload(version string) interface{} {
+	if versions.IsNewerThan(version, versions.LastStringCustomRules) {
+		return &UserRulesRequest{Rules: ur}
+	}
+	return ur.String()
 }
 
 // UserRulesRequest API struct

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -210,6 +210,16 @@ func (ur UserRules) String() string {
 	return strings.Join(ur, "\n")
 }
 
+// UserRulesRequest API struct
+type UserRulesRequest struct {
+	Rules UserRules
+}
+
+// String toString of Users
+func (ur UserRulesRequest) String() string {
+	return ur.Rules.String()
+}
+
 // EnableConfig API struct
 type EnableConfig struct {
 	Enabled bool `json:"enabled"`

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/bakito/adguardhome-sync/pkg/types"
+	"github.com/bakito/adguardhome-sync/pkg/versions"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -215,6 +216,26 @@ var _ = Describe("Types", func() {
 			r2 := uuid.NewString()
 			ur := types.UserRules([]string{r1, r2})
 			Ω(ur.String()).Should(Equal(r1 + "\n" + r2))
+		})
+		It("should return a string for versions <= "+versions.LastStringCustomRules, func() {
+			r1 := uuid.NewString()
+			r2 := uuid.NewString()
+			pl := types.UserRules([]string{r1, r2}).ToPayload(versions.LastStringCustomRules)
+			Ω(pl).Should(BeAssignableToTypeOf(""))
+		})
+		It("should return a struct for versions > "+versions.IncompatibleAPI, func() {
+			r1 := uuid.NewString()
+			r2 := uuid.NewString()
+			pl := types.UserRules([]string{r1, r2}).ToPayload(versions.FixedIncompatibleAPI)
+			Ω(pl).Should(BeAssignableToTypeOf(&types.UserRulesRequest{}))
+		})
+	})
+	Context("UserRulesRequest", func() {
+		It("should join the rules correctly", func() {
+			r1 := uuid.NewString()
+			r2 := uuid.NewString()
+			urr := types.UserRulesRequest{Rules: []string{r1, r2}}
+			Ω(urr.String()).Should(Equal(r1 + "\n" + r2))
 		})
 	})
 	Context("Config", func() {

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -3,10 +3,23 @@ package versions
 import "golang.org/x/mod/semver"
 
 const (
+	// MinAgh minimal adguardhome version
+	MinAgh = "v0.107.0"
+	// LastStringCustomRules last adguardhome version with string payload custom rules
+	// https://github.com/bakito/adguardhome-sync/issues/99
 	LastStringCustomRules = "v0.107.13"
-	MinAgh                = "v0.107.0"
+	// IncompatibleAPI adguardhome  version with incompatible API
+	// https://github.com/bakito/adguardhome-sync/issues/99
+	IncompatibleAPI = "v0.107.14"
+	// FixedIncompatibleAPI adguardhome version with fixed API
+	// https://github.com/bakito/adguardhome-sync/issues/99
+	FixedIncompatibleAPI = "v0.107.15"
 )
 
 func IsNewerThan(v1 string, v2 string) bool {
 	return semver.Compare(v1, v2) == 1
+}
+
+func IsSame(v1 string, v2 string) bool {
+	return semver.Compare(v1, v2) == 0
 }

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -1,0 +1,12 @@
+package versions
+
+import "golang.org/x/mod/semver"
+
+const (
+	LastStringCustomRules = "v0.107.13"
+	MinAgh                = "v0.107.0"
+)
+
+func IsNewerThan(v1 string, v2 string) bool {
+	return semver.Compare(v1, v2) == 1
+}


### PR DESCRIPTION
v0.107.14 of adguardhome introduces an inconsistency in the API that is fixed in v0.107.15.

This PR fixes the API change from string to json payload in the '/filtering/set_rules' POST method.
It remains backward compatible with older versions.

v0.107.14 seem so have an inconsistent check in the API and can not be uses with adguardhome-sync therefore the version is blocked ad replica targets.