### PR TITLE
Sanitize dns config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,10 @@ kind-test:
 
 model: oapi-codegen
 	@mkdir -p tmp
-	go run openapi/main.go v0.107.44
+	go run openapi/main.go v0.107.46
 	$(OAPI_CODEGEN) -package model -generate types,client -config .oapi-codegen.yaml tmp/schema.yaml > pkg/client/model/model_generated.go
 
 model-diff:
-	go run openapi/main.go v0.107.44
+	go run openapi/main.go v0.107.46
 	go run openapi/main.go
 	diff tmp/schema.yaml tmp/schema-master.yaml

--- a/pkg/client/model/model-functions.go
+++ b/pkg/client/model/model-functions.go
@@ -401,3 +401,11 @@ func ArrayString(a *[]string) string {
 	sort.Strings(sorted)
 	return fmt.Sprintf("[%s]", strings.Join(sorted, ","))
 }
+
+func (c *DNSConfig) Sanitize() {
+	// disable UsePrivatePtrResolvers if not configured
+	if c.UsePrivatePtrResolvers != nil && *c.UsePrivatePtrResolvers == true &&
+		(c.LocalPtrUpstreams == nil || len(*c.LocalPtrUpstreams) == 0) {
+		c.UsePrivatePtrResolvers = utils.Ptr(false)
+	}
+}

--- a/pkg/client/model/model-functions.go
+++ b/pkg/client/model/model-functions.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bakito/adguardhome-sync/pkg/utils"
 	"github.com/jinzhu/copier"
+	"go.uber.org/zap"
 )
 
 // Clone the config
@@ -402,10 +403,11 @@ func ArrayString(a *[]string) string {
 	return fmt.Sprintf("[%s]", strings.Join(sorted, ","))
 }
 
-func (c *DNSConfig) Sanitize() {
+func (c *DNSConfig) Sanitize(l *zap.SugaredLogger) {
 	// disable UsePrivatePtrResolvers if not configured
-	if c.UsePrivatePtrResolvers != nil && *c.UsePrivatePtrResolvers == true &&
+	if c.UsePrivatePtrResolvers != nil && *c.UsePrivatePtrResolvers &&
 		(c.LocalPtrUpstreams == nil || len(*c.LocalPtrUpstreams) == 0) {
+		l.Warn("disabling replica 'Use private reverse DNS resolvers' as no 'Private reverse DNS servers' are configured on origin")
 		c.UsePrivatePtrResolvers = utils.Ptr(false)
 	}
 }

--- a/pkg/client/model/model_private_test.go
+++ b/pkg/client/model/model_private_test.go
@@ -1,9 +1,11 @@
 package model
 
 import (
+	"github.com/bakito/adguardhome-sync/pkg/log"
 	"github.com/bakito/adguardhome-sync/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"go.uber.org/zap"
 )
 
 var _ = Describe("Types", func() {
@@ -70,5 +72,32 @@ var _ = Describe("Types", func() {
 			Entry(`When SubnetMask is nil`, DhcpConfigV6{RangeStart: nil}),
 			Entry(`When SubnetMask is ""`, DhcpConfigV6{RangeStart: utils.Ptr("")}),
 		)
+	})
+	Context("DNSConfig", func() {
+		var (
+			cfg *DNSConfig
+			l   *zap.SugaredLogger
+		)
+
+		BeforeEach(func() {
+			cfg = &DNSConfig{
+				UsePrivatePtrResolvers: utils.Ptr(true),
+			}
+			l = log.GetLogger("test")
+		})
+		Context("Sanitize", func() {
+			It("should disable UsePrivatePtrResolvers resolvers is nil ", func() {
+				cfg.LocalPtrUpstreams = nil
+				cfg.Sanitize(l)
+				gomega.Ω(cfg.UsePrivatePtrResolvers).ShouldNot(gomega.BeNil())
+				gomega.Ω(*cfg.UsePrivatePtrResolvers).Should(gomega.Equal(false))
+			})
+			It("should disable UsePrivatePtrResolvers resolvers is empty ", func() {
+				cfg.LocalPtrUpstreams = utils.Ptr([]string{})
+				cfg.Sanitize(l)
+				gomega.Ω(cfg.UsePrivatePtrResolvers).ShouldNot(gomega.BeNil())
+				gomega.Ω(*cfg.UsePrivatePtrResolvers).Should(gomega.Equal(false))
+			})
+		})
 	})
 })

--- a/pkg/sync/action-general.go
+++ b/pkg/sync/action-general.go
@@ -187,10 +187,9 @@ var (
 			return err
 		}
 
-		dc.Sanitize()
+		dc.Sanitize(ac.rl)
 
 		if !dc.Equals(ac.origin.dnsConfig) {
-
 			if err = ac.client.SetDNSConfig(ac.origin.dnsConfig); err != nil {
 				return err
 			}

--- a/pkg/sync/action-general.go
+++ b/pkg/sync/action-general.go
@@ -186,7 +186,11 @@ var (
 		if err != nil {
 			return err
 		}
+
+		dc.Sanitize()
+
 		if !dc.Equals(ac.origin.dnsConfig) {
+
 			if err = ac.client.SetDNSConfig(ac.origin.dnsConfig); err != nil {
 				return err
 			}


### PR DESCRIPTION
set 'Use private reverse DNS resolvers' automatically to false on replica if 'Private reverse DNS servers' are empty, even if the flag is enabled on origin.
fixes #320

related with https://github.com/AdguardTeam/AdGuardHome/issues/6820 