### PR TITLE
Replace deprecated API endpoints

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -109,9 +109,7 @@ type Client interface {
 	SetSafeSearchConfig(settings *model.SafeSearchConfig) error
 	ProfileInfo() (*model.ProfileInfo, error)
 	SetProfileInfo(settings *model.ProfileInfo) error
-	BlockedServices() (*model.BlockedServicesArray, error)
 	BlockedServicesSchedule() (*model.BlockedServicesSchedule, error)
-	SetBlockedServices(services *model.BlockedServicesArray) error
 	SetBlockedServicesSchedule(schedule *model.BlockedServicesSchedule) error
 	Clients() (*model.Clients, error)
 	AddClient(client *model.Client) error
@@ -287,17 +285,6 @@ func (cl *client) ToggleFiltering(enabled bool, interval int) error {
 	}), "/filtering/config")
 }
 
-func (cl *client) BlockedServices() (*model.BlockedServicesArray, error) {
-	svcs := &model.BlockedServicesArray{}
-	err := cl.doGet(cl.client.R().EnableTrace().SetResult(svcs), "/blocked_services/list")
-	return svcs, err
-}
-
-func (cl *client) SetBlockedServices(services *model.BlockedServicesArray) error {
-	cl.log.With("services", model.ArrayString(services)).Info("Set blocked services")
-	return cl.doPost(cl.client.R().EnableTrace().SetBody(services), "/blocked_services/set")
-}
-
 func (cl *client) BlockedServicesSchedule() (*model.BlockedServicesSchedule, error) {
 	sched := &model.BlockedServicesSchedule{}
 	err := cl.doGet(cl.client.R().EnableTrace().SetResult(sched), "/blocked_services/get")
@@ -343,13 +330,13 @@ func (cl *client) SetQueryLogConfig(qlc *model.QueryLogConfigWithIgnored) error 
 
 func (cl *client) StatsConfig() (*model.StatsConfig, error) {
 	stats := &model.StatsConfig{}
-	err := cl.doGet(cl.client.R().EnableTrace().SetResult(stats), "/stats_info")
+	err := cl.doGet(cl.client.R().EnableTrace().SetResult(stats), "/stats/config")
 	return stats, err
 }
 
 func (cl *client) SetStatsConfig(sc *model.StatsConfig) error {
 	cl.log.With("interval", *sc.Interval).Info("Set stats config")
-	return cl.doPost(cl.client.R().EnableTrace().SetBody(sc), "/stats_config")
+	return cl.doPut(cl.client.R().EnableTrace().SetBody(sc), "/stats/config/update")
 }
 
 func (cl *client) Setup() error {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -117,8 +117,8 @@ type Client interface {
 	DeleteClient(client *model.Client) error
 	QueryLogConfig() (*model.QueryLogConfigWithIgnored, error)
 	SetQueryLogConfig(*model.QueryLogConfigWithIgnored) error
-	StatsConfig() (*model.StatsConfig, error)
-	SetStatsConfig(sc *model.StatsConfig) error
+	StatsConfig() (*model.GetStatsConfigResponse, error)
+	SetStatsConfig(sc *model.PutStatsConfigUpdateRequest) error
 	Setup() error
 	AccessList() (*model.AccessList, error)
 	SetAccessList(*model.AccessList) error
@@ -328,14 +328,14 @@ func (cl *client) SetQueryLogConfig(qlc *model.QueryLogConfigWithIgnored) error 
 	return cl.doPut(cl.client.R().EnableTrace().SetBody(qlc), "/querylog/config/update")
 }
 
-func (cl *client) StatsConfig() (*model.StatsConfig, error) {
-	stats := &model.StatsConfig{}
+func (cl *client) StatsConfig() (*model.GetStatsConfigResponse, error) {
+	stats := &model.GetStatsConfigResponse{}
 	err := cl.doGet(cl.client.R().EnableTrace().SetResult(stats), "/stats/config")
 	return stats, err
 }
 
-func (cl *client) SetStatsConfig(sc *model.StatsConfig) error {
-	cl.log.With("interval", *sc.Interval).Info("Set stats config")
+func (cl *client) SetStatsConfig(sc *model.PutStatsConfigUpdateRequest) error {
+	cl.log.With("interval", sc.Interval).Info("Set stats config")
 	return cl.doPut(cl.client.R().EnableTrace().SetBody(sc), "/stats/config/update")
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -117,8 +117,8 @@ type Client interface {
 	AddClient(client *model.Client) error
 	UpdateClient(client *model.Client) error
 	DeleteClient(client *model.Client) error
-	QueryLogConfig() (*model.QueryLogConfig, error)
-	SetQueryLogConfig(*model.QueryLogConfig) error
+	QueryLogConfig() (*model.QueryLogConfigWithIgnored, error)
+	SetQueryLogConfig(*model.QueryLogConfigWithIgnored) error
 	StatsConfig() (*model.StatsConfig, error)
 	SetStatsConfig(sc *model.StatsConfig) error
 	Setup() error
@@ -330,15 +330,15 @@ func (cl *client) DeleteClient(client *model.Client) error {
 	return cl.doPost(cl.client.R().EnableTrace().SetBody(client), "/clients/delete")
 }
 
-func (cl *client) QueryLogConfig() (*model.QueryLogConfig, error) {
-	qlc := &model.QueryLogConfig{}
-	err := cl.doGet(cl.client.R().EnableTrace().SetResult(qlc), "/querylog_info")
+func (cl *client) QueryLogConfig() (*model.QueryLogConfigWithIgnored, error) {
+	qlc := &model.QueryLogConfigWithIgnored{}
+	err := cl.doGet(cl.client.R().EnableTrace().SetResult(qlc), "/querylog/config")
 	return qlc, err
 }
 
-func (cl *client) SetQueryLogConfig(qlc *model.QueryLogConfig) error {
+func (cl *client) SetQueryLogConfig(qlc *model.QueryLogConfigWithIgnored) error {
 	cl.log.With("enabled", *qlc.Enabled, "interval", *qlc.Interval, "anonymizeClientIP", *qlc.AnonymizeClientIp).Info("Set query log config")
-	return cl.doPost(cl.client.R().EnableTrace().SetBody(qlc), "/querylog_config")
+	return cl.doPut(cl.client.R().EnableTrace().SetBody(qlc), "/querylog/config/update")
 }
 
 func (cl *client) StatsConfig() (*model.StatsConfig, error) {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -323,13 +323,13 @@ var _ = Describe("Client", func() {
 			sc, err := cl.StatsConfig()
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(sc.Interval).ShouldNot(BeNil())
-			Ω(*sc.Interval).Should(Equal(model.StatsConfigInterval(1)))
+			Ω(sc.Interval).Should(Equal(float32(1)))
 		})
 		It("should set StatsConfig", func() {
-			ts, cl = ClientPost("/stats/config/update", `{"interval":123}`)
+			ts, cl = ClientPost("/stats/config/update", `{"enabled":false,"ignored":null,"interval":123}`)
 
-			var interval model.StatsConfigInterval = 123
-			err := cl.SetStatsConfig(&model.StatsConfig{Interval: &interval})
+			var interval float32 = 123
+			err := cl.SetStatsConfig(&model.PutStatsConfigUpdateRequest{Interval: interval})
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 	})
@@ -354,8 +354,8 @@ var _ = Describe("Client", func() {
 
 		Context("doPost", func() {
 			It("should return an error on status code != 200", func() {
-				var interval model.StatsConfigInterval = 123
-				err := cl.SetStatsConfig(&model.StatsConfig{Interval: &interval})
+				var interval float32 = 123
+				err := cl.SetStatsConfig(&model.PutStatsConfigUpdateRequest{Interval: interval})
 				Ω(err).Should(HaveOccurred())
 				Ω(err.Error()).Should(Equal("401 Unauthorized"))
 			})

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -308,7 +308,7 @@ var _ = Describe("Client", func() {
 
 	Context("QueryLogConfig", func() {
 		It("should read QueryLogConfig", func() {
-			ts, cl = ClientGet("querylog_info.json", "/querylog_info")
+			ts, cl = ClientGet("querylog_config.json", "/querylog/config")
 			qlc, err := cl.QueryLogConfig()
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(qlc.Enabled).ShouldNot(BeNil())
@@ -317,10 +317,17 @@ var _ = Describe("Client", func() {
 			Ω(*qlc.Interval).Should(Equal(model.QueryLogConfigInterval(90)))
 		})
 		It("should set QueryLogConfig", func() {
-			ts, cl = ClientPost("/querylog_config", `{"anonymize_client_ip":true,"enabled":true,"interval":123}`)
+			ts, cl = ClientPut("/querylog/config/update", `{"anonymize_client_ip":true,"enabled":true,"interval":123,"ignored":["foo.bar"]}`)
 
 			var interval model.QueryLogConfigInterval = 123
-			err := cl.SetQueryLogConfig(&model.QueryLogConfig{AnonymizeClientIp: utils.Ptr(true), Interval: &interval, Enabled: utils.Ptr(true)})
+			err := cl.SetQueryLogConfig(&model.QueryLogConfigWithIgnored{
+				QueryLogConfig: model.QueryLogConfig{
+					AnonymizeClientIp: utils.Ptr(true),
+					Interval:          &interval,
+					Enabled:           utils.Ptr(true),
+				},
+				Ignored: []string{"foo.bar"},
+			})
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 	})

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -239,20 +239,6 @@ var _ = Describe("Client", func() {
 		})
 	})
 
-	Context("BlockedServices", func() {
-		It("should read BlockedServices", func() {
-			ts, cl = ClientGet("blockedservices-list.json", "/blocked_services/list")
-			s, err := cl.BlockedServices()
-			Ω(err).ShouldNot(HaveOccurred())
-			Ω(*s).Should(HaveLen(2))
-		})
-		It("should set BlockedServices", func() {
-			ts, cl = ClientPost("/blocked_services/set", `["bar","foo"]`)
-			err := cl.SetBlockedServices(&model.BlockedServicesArray{"foo", "bar"})
-			Ω(err).ShouldNot(HaveOccurred())
-		})
-	})
-
 	Context("BlockedServicesSchedule", func() {
 		It("should read BlockedServicesSchedule", func() {
 			ts, cl = ClientGet("blockedservicesschedule-get.json", "/blocked_services/get")
@@ -333,14 +319,14 @@ var _ = Describe("Client", func() {
 	})
 	Context("StatsConfig", func() {
 		It("should read StatsConfig", func() {
-			ts, cl = ClientGet("stats_info.json", "/stats_info")
+			ts, cl = ClientGet("stats_info.json", "/stats/config")
 			sc, err := cl.StatsConfig()
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(sc.Interval).ShouldNot(BeNil())
 			Ω(*sc.Interval).Should(Equal(model.StatsConfigInterval(1)))
 		})
 		It("should set StatsConfig", func() {
-			ts, cl = ClientPost("/stats_config", `{"interval":123}`)
+			ts, cl = ClientPost("/stats/config/update", `{"interval":123}`)
 
 			var interval model.StatsConfigInterval = 123
 			err := cl.SetStatsConfig(&model.StatsConfig{Interval: &interval})

--- a/pkg/client/model/model-functions.go
+++ b/pkg/client/model/model-functions.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bakito/adguardhome-sync/pkg/utils"
 	"github.com/jinzhu/copier"
 	"go.uber.org/zap"
+	"golang.org/x/exp/slices"
 )
 
 // Clone the config
@@ -321,11 +322,19 @@ func (f *Filter) Equals(o *Filter) bool {
 	return f.Enabled == o.Enabled && f.Url == o.Url && f.Name == o.Name
 }
 
+type QueryLogConfigWithIgnored struct {
+	QueryLogConfig
+
+	// Ignored List of host names, which should not be written to log
+	Ignored []string `json:"ignored,omitempty"`
+}
+
 // Equals QueryLogConfig equal check
-func (qlc *QueryLogConfig) Equals(o *QueryLogConfig) bool {
+func (qlc *QueryLogConfigWithIgnored) Equals(o *QueryLogConfigWithIgnored) bool {
 	return ptrEquals(qlc.Enabled, o.Enabled) &&
 		ptrEquals(qlc.AnonymizeClientIp, o.AnonymizeClientIp) &&
-		qlc.Interval.Equals(o.Interval)
+		qlc.Interval.Equals(o.Interval) &&
+		slices.Equal(qlc.Ignored, o.Ignored)
 }
 
 // Equals QueryLogConfigInterval equal check

--- a/pkg/client/model/model-functions.go
+++ b/pkg/client/model/model-functions.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bakito/adguardhome-sync/pkg/utils"
 	"github.com/jinzhu/copier"
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
 )
 
 // Clone the config
@@ -331,10 +330,7 @@ type QueryLogConfigWithIgnored struct {
 
 // Equals QueryLogConfig equal check
 func (qlc *QueryLogConfigWithIgnored) Equals(o *QueryLogConfigWithIgnored) bool {
-	return ptrEquals(qlc.Enabled, o.Enabled) &&
-		ptrEquals(qlc.AnonymizeClientIp, o.AnonymizeClientIp) &&
-		qlc.Interval.Equals(o.Interval) &&
-		slices.Equal(qlc.Ignored, o.Ignored)
+	return utils.JsonEquals(qlc, o)
 }
 
 // Equals QueryLogConfigInterval equal check
@@ -419,4 +415,9 @@ func (c *DNSConfig) Sanitize(l *zap.SugaredLogger) {
 		l.Warn("disabling replica 'Use private reverse DNS resolvers' as no 'Private reverse DNS servers' are configured on origin")
 		c.UsePrivatePtrResolvers = utils.Ptr(false)
 	}
+}
+
+// Equals GetStatsConfigResponse equal check
+func (sc *GetStatsConfigResponse) Equals(o *GetStatsConfigResponse) bool {
+	return utils.JsonEquals(sc, o)
 }

--- a/pkg/client/model/model_test.go
+++ b/pkg/client/model/model_test.go
@@ -115,12 +115,12 @@ var _ = Describe("Types", func() {
 	Context("QueryLogConfig", func() {
 		Context("Equal", func() {
 			var (
-				a *model.QueryLogConfig
-				b *model.QueryLogConfig
+				a *model.QueryLogConfigWithIgnored
+				b *model.QueryLogConfigWithIgnored
 			)
 			BeforeEach(func() {
-				a = &model.QueryLogConfig{}
-				b = &model.QueryLogConfig{}
+				a = &model.QueryLogConfigWithIgnored{}
+				b = &model.QueryLogConfigWithIgnored{}
 			})
 			It("should be equal", func() {
 				a.Enabled = utils.Ptr(true)

--- a/pkg/mocks/client/mock.go
+++ b/pkg/mocks/client/mock.go
@@ -114,21 +114,6 @@ func (mr *MockClientMockRecorder) AddRewriteEntries(arg0 ...any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRewriteEntries", reflect.TypeOf((*MockClient)(nil).AddRewriteEntries), arg0...)
 }
 
-// BlockedServices mocks base method.
-func (m *MockClient) BlockedServices() (*[]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockedServices")
-	ret0, _ := ret[0].(*[]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BlockedServices indicates an expected call of BlockedServices.
-func (mr *MockClientMockRecorder) BlockedServices() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockedServices", reflect.TypeOf((*MockClient)(nil).BlockedServices))
-}
-
 // BlockedServicesSchedule mocks base method.
 func (m *MockClient) BlockedServicesSchedule() (*model.BlockedServicesSchedule, error) {
 	m.ctrl.T.Helper()
@@ -409,20 +394,6 @@ func (m *MockClient) SetAccessList(arg0 *model.AccessList) error {
 func (mr *MockClientMockRecorder) SetAccessList(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAccessList", reflect.TypeOf((*MockClient)(nil).SetAccessList), arg0)
-}
-
-// SetBlockedServices mocks base method.
-func (m *MockClient) SetBlockedServices(arg0 *[]string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetBlockedServices", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetBlockedServices indicates an expected call of SetBlockedServices.
-func (mr *MockClientMockRecorder) SetBlockedServices(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBlockedServices", reflect.TypeOf((*MockClient)(nil).SetBlockedServices), arg0)
 }
 
 // SetBlockedServicesSchedule mocks base method.

--- a/pkg/mocks/client/mock.go
+++ b/pkg/mocks/client/mock.go
@@ -324,10 +324,10 @@ func (mr *MockClientMockRecorder) QueryLog(arg0 any) *gomock.Call {
 }
 
 // QueryLogConfig mocks base method.
-func (m *MockClient) QueryLogConfig() (*model.QueryLogConfig, error) {
+func (m *MockClient) QueryLogConfig() (*model.QueryLogConfigWithIgnored, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "QueryLogConfig")
-	ret0, _ := ret[0].(*model.QueryLogConfig)
+	ret0, _ := ret[0].(*model.QueryLogConfigWithIgnored)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -496,7 +496,7 @@ func (mr *MockClientMockRecorder) SetProfileInfo(arg0 any) *gomock.Call {
 }
 
 // SetQueryLogConfig mocks base method.
-func (m *MockClient) SetQueryLogConfig(arg0 *model.QueryLogConfig) error {
+func (m *MockClient) SetQueryLogConfig(arg0 *model.QueryLogConfigWithIgnored) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetQueryLogConfig", arg0)
 	ret0, _ := ret[0].(error)

--- a/pkg/mocks/client/mock.go
+++ b/pkg/mocks/client/mock.go
@@ -495,7 +495,7 @@ func (mr *MockClientMockRecorder) SetSafeSearchConfig(arg0 any) *gomock.Call {
 }
 
 // SetStatsConfig mocks base method.
-func (m *MockClient) SetStatsConfig(arg0 *model.StatsConfig) error {
+func (m *MockClient) SetStatsConfig(arg0 *model.GetStatsConfigResponse) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatsConfig", arg0)
 	ret0, _ := ret[0].(error)
@@ -538,10 +538,10 @@ func (mr *MockClientMockRecorder) Stats() *gomock.Call {
 }
 
 // StatsConfig mocks base method.
-func (m *MockClient) StatsConfig() (*model.StatsConfig, error) {
+func (m *MockClient) StatsConfig() (*model.GetStatsConfigResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StatsConfig")
-	ret0, _ := ret[0].(*model.StatsConfig)
+	ret0, _ := ret[0].(*model.GetStatsConfigResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/sync/action-general.go
+++ b/pkg/sync/action-general.go
@@ -63,7 +63,7 @@ var (
 		if err != nil {
 			return err
 		}
-		if ac.origin.statsConfig.Interval != sc.Interval {
+		if !sc.Equals(ac.origin.statsConfig) {
 			return ac.client.SetStatsConfig(ac.origin.statsConfig)
 		}
 		return nil

--- a/pkg/sync/action-general.go
+++ b/pkg/sync/action-general.go
@@ -111,17 +111,6 @@ var (
 		return nil
 	}
 
-	actionBlockedServices = func(ac *actionContext) error {
-		rs, err := ac.client.BlockedServices()
-		if err != nil {
-			return err
-		}
-
-		if !model.EqualsStringSlice(ac.origin.blockedServices, rs, true) {
-			return ac.client.SetBlockedServices(ac.origin.blockedServices)
-		}
-		return nil
-	}
 	actionBlockedServicesSchedule = func(ac *actionContext) error {
 		rbss, err := ac.client.BlockedServicesSchedule()
 		if err != nil {

--- a/pkg/sync/action.go
+++ b/pkg/sync/action.go
@@ -39,7 +39,6 @@ func setupActions(cfg *types.Config) (actions []syncAction) {
 	}
 	if cfg.Features.Services {
 		actions = append(actions,
-			action("blocked services", actionBlockedServices),
 			action("blocked services schedule", actionBlockedServicesSchedule),
 		)
 	}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -325,7 +325,7 @@ type origin struct {
 	filters                 *model.FilterStatus
 	clients                 *model.Clients
 	queryLogConfig          *model.QueryLogConfigWithIgnored
-	statsConfig             *model.StatsConfig
+	statsConfig             *model.GetStatsConfigResponse
 	accessList              *model.AccessList
 	dnsConfig               *model.DNSConfig
 	dhcpServerConfig        *model.DhcpStatus

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -331,7 +331,7 @@ type origin struct {
 	blockedServicesSchedule *model.BlockedServicesSchedule
 	filters                 *model.FilterStatus
 	clients                 *model.Clients
-	queryLogConfig          *model.QueryLogConfig
+	queryLogConfig          *model.QueryLogConfigWithIgnored
 	statsConfig             *model.StatsConfig
 	accessList              *model.AccessList
 	dnsConfig               *model.DNSConfig

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -201,12 +201,6 @@ func (w *worker) sync() {
 		return
 	}
 
-	o.blockedServices, err = oc.BlockedServices()
-	if err != nil {
-		sl.With("error", err).Error("Error getting origin blocked services")
-		return
-	}
-
 	o.blockedServicesSchedule, err = oc.BlockedServicesSchedule()
 	if err != nil {
 		sl.With("error", err).Error("Error getting origin blocked services schedule")
@@ -327,7 +321,6 @@ func (w *worker) statusWithSetup(rl *zap.SugaredLogger, replica types.AdGuardIns
 type origin struct {
 	status                  *model.ServerStatus
 	rewrites                *model.RewriteEntries
-	blockedServices         *model.BlockedServicesArray
 	blockedServicesSchedule *model.BlockedServicesSchedule
 	filters                 *model.FilterStatus
 	clients                 *model.Clients

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Sync", func() {
 				},
 				status:         &model.ServerStatus{},
 				safeSearch:     &model.SafeSearchConfig{},
-				queryLogConfig: &model.QueryLogConfig{},
+				queryLogConfig: &model.QueryLogConfigWithIgnored{},
 				statsConfig:    &model.StatsConfig{},
 			},
 			replicaStatus: &model.ServerStatus{},
@@ -289,9 +289,9 @@ var _ = Describe("Sync", func() {
 			})
 		})
 		Context("actionQueryLogConfig", func() {
-			var qlc *model.QueryLogConfig
+			var qlc *model.QueryLogConfigWithIgnored
 			BeforeEach(func() {
-				qlc = &model.QueryLogConfig{}
+				qlc = &model.QueryLogConfigWithIgnored{}
 			})
 			It("should have no changes", func() {
 				cl.EXPECT().QueryLogConfig().Return(qlc, nil)
@@ -302,7 +302,7 @@ var _ = Describe("Sync", func() {
 				var interval model.QueryLogConfigInterval = 123
 				ac.origin.queryLogConfig.Interval = &interval
 				cl.EXPECT().QueryLogConfig().Return(qlc, nil)
-				cl.EXPECT().SetQueryLogConfig(&model.QueryLogConfig{AnonymizeClientIp: nil, Interval: &interval, Enabled: nil})
+				cl.EXPECT().SetQueryLogConfig(&model.QueryLogConfigWithIgnored{QueryLogConfig: model.QueryLogConfig{AnonymizeClientIp: nil, Interval: &interval, Enabled: nil}})
 				err := actionQueryLogConfig(ac)
 				Ω(err).ShouldNot(HaveOccurred())
 			})
@@ -603,7 +603,7 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().BlockedServicesSchedule()
 				cl.EXPECT().Filtering().Return(&model.FilterStatus{}, nil)
 				cl.EXPECT().Clients().Return(&model.Clients{}, nil)
-				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfig{}, nil)
+				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfigWithIgnored{}, nil)
 				cl.EXPECT().StatsConfig().Return(&model.StatsConfig{}, nil)
 				cl.EXPECT().AccessList().Return(&model.AccessList{}, nil)
 				cl.EXPECT().DNSConfig().Return(&model.DNSConfig{}, nil)
@@ -616,7 +616,7 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().Parental()
 				cl.EXPECT().SafeSearchConfig().Return(&model.SafeSearchConfig{}, nil)
 				cl.EXPECT().SafeBrowsing()
-				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfig{}, nil)
+				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfigWithIgnored{}, nil)
 				cl.EXPECT().StatsConfig().Return(&model.StatsConfig{}, nil)
 				cl.EXPECT().RewriteList().Return(&model.RewriteEntries{}, nil)
 				cl.EXPECT().AddRewriteEntries()
@@ -645,7 +645,7 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().BlockedServicesSchedule()
 				cl.EXPECT().Filtering().Return(&model.FilterStatus{}, nil)
 				cl.EXPECT().Clients().Return(&model.Clients{}, nil)
-				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfig{}, nil)
+				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfigWithIgnored{}, nil)
 				cl.EXPECT().StatsConfig().Return(&model.StatsConfig{}, nil)
 				cl.EXPECT().AccessList().Return(&model.AccessList{}, nil)
 				cl.EXPECT().DNSConfig().Return(&model.DNSConfig{}, nil)
@@ -657,7 +657,7 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().Parental()
 				cl.EXPECT().SafeSearchConfig().Return(&model.SafeSearchConfig{}, nil)
 				cl.EXPECT().SafeBrowsing()
-				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfig{}, nil)
+				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfigWithIgnored{}, nil)
 				cl.EXPECT().StatsConfig().Return(&model.StatsConfig{}, nil)
 				cl.EXPECT().RewriteList().Return(&model.RewriteEntries{}, nil)
 				cl.EXPECT().AddRewriteEntries()
@@ -689,7 +689,7 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().BlockedServicesSchedule()
 				cl.EXPECT().Filtering().Return(&model.FilterStatus{}, nil)
 				cl.EXPECT().Clients().Return(&model.Clients{}, nil)
-				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfig{}, nil)
+				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfigWithIgnored{}, nil)
 				cl.EXPECT().StatsConfig().Return(&model.StatsConfig{}, nil)
 				cl.EXPECT().AccessList().Return(&model.AccessList{}, nil)
 				cl.EXPECT().DNSConfig().Return(&model.DNSConfig{}, nil)

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Sync", func() {
 				status:         &model.ServerStatus{},
 				safeSearch:     &model.SafeSearchConfig{},
 				queryLogConfig: &model.QueryLogConfigWithIgnored{},
-				statsConfig:    &model.StatsConfig{},
+				statsConfig:    &model.PutStatsConfigUpdateRequest{},
 			},
 			replicaStatus: &model.ServerStatus{},
 			client:        cl,
@@ -308,9 +308,9 @@ var _ = Describe("Sync", func() {
 			})
 		})
 		Context("syncConfigs", func() {
-			var sc *model.StatsConfig
+			var sc *model.PutStatsConfigUpdateRequest
 			BeforeEach(func() {
-				sc = &model.StatsConfig{}
+				sc = &model.PutStatsConfigUpdateRequest{}
 			})
 			It("should have no changes", func() {
 				cl.EXPECT().StatsConfig().Return(sc, nil)
@@ -318,10 +318,10 @@ var _ = Describe("Sync", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 			})
 			It("should have StatsConfig changes", func() {
-				var interval model.StatsConfigInterval = 123
-				ac.origin.statsConfig.Interval = &interval
+				var interval float32 = 123
+				ac.origin.statsConfig.Interval = interval
 				cl.EXPECT().StatsConfig().Return(sc, nil)
-				cl.EXPECT().SetStatsConfig(&model.StatsConfig{Interval: &interval})
+				cl.EXPECT().SetStatsConfig(&model.PutStatsConfigUpdateRequest{Interval: interval})
 				err := actionStatsConfig(ac)
 				Ω(err).ShouldNot(HaveOccurred())
 			})
@@ -583,7 +583,7 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().Filtering().Return(&model.FilterStatus{}, nil)
 				cl.EXPECT().Clients().Return(&model.Clients{}, nil)
 				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfigWithIgnored{}, nil)
-				cl.EXPECT().StatsConfig().Return(&model.StatsConfig{}, nil)
+				cl.EXPECT().StatsConfig().Return(&model.PutStatsConfigUpdateRequest{}, nil)
 				cl.EXPECT().AccessList().Return(&model.AccessList{}, nil)
 				cl.EXPECT().DNSConfig().Return(&model.DNSConfig{}, nil)
 				cl.EXPECT().DhcpConfig().Return(&model.DhcpStatus{}, nil)
@@ -596,7 +596,7 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().SafeSearchConfig().Return(&model.SafeSearchConfig{}, nil)
 				cl.EXPECT().SafeBrowsing()
 				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfigWithIgnored{}, nil)
-				cl.EXPECT().StatsConfig().Return(&model.StatsConfig{}, nil)
+				cl.EXPECT().StatsConfig().Return(&model.PutStatsConfigUpdateRequest{}, nil)
 				cl.EXPECT().RewriteList().Return(&model.RewriteEntries{}, nil)
 				cl.EXPECT().AddRewriteEntries()
 				cl.EXPECT().DeleteRewriteEntries()
@@ -623,7 +623,7 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().Filtering().Return(&model.FilterStatus{}, nil)
 				cl.EXPECT().Clients().Return(&model.Clients{}, nil)
 				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfigWithIgnored{}, nil)
-				cl.EXPECT().StatsConfig().Return(&model.StatsConfig{}, nil)
+				cl.EXPECT().StatsConfig().Return(&model.PutStatsConfigUpdateRequest{}, nil)
 				cl.EXPECT().AccessList().Return(&model.AccessList{}, nil)
 				cl.EXPECT().DNSConfig().Return(&model.DNSConfig{}, nil)
 
@@ -635,7 +635,7 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().SafeSearchConfig().Return(&model.SafeSearchConfig{}, nil)
 				cl.EXPECT().SafeBrowsing()
 				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfigWithIgnored{}, nil)
-				cl.EXPECT().StatsConfig().Return(&model.StatsConfig{}, nil)
+				cl.EXPECT().StatsConfig().Return(&model.PutStatsConfigUpdateRequest{}, nil)
 				cl.EXPECT().RewriteList().Return(&model.RewriteEntries{}, nil)
 				cl.EXPECT().AddRewriteEntries()
 				cl.EXPECT().DeleteRewriteEntries()
@@ -665,7 +665,7 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().Filtering().Return(&model.FilterStatus{}, nil)
 				cl.EXPECT().Clients().Return(&model.Clients{}, nil)
 				cl.EXPECT().QueryLogConfig().Return(&model.QueryLogConfigWithIgnored{}, nil)
-				cl.EXPECT().StatsConfig().Return(&model.StatsConfig{}, nil)
+				cl.EXPECT().StatsConfig().Return(&model.PutStatsConfigUpdateRequest{}, nil)
 				cl.EXPECT().AccessList().Return(&model.AccessList{}, nil)
 				cl.EXPECT().DNSConfig().Return(&model.DNSConfig{}, nil)
 				cl.EXPECT().DhcpConfig().Return(&model.DhcpStatus{}, nil)

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -359,26 +359,6 @@ var _ = Describe("Sync", func() {
 				Ω(st).Should(BeNil())
 			})
 		})
-		Context("actionBlockedServices", func() {
-			var rbs *model.BlockedServicesArray
-			BeforeEach(func() {
-				ac.origin.blockedServices = &model.BlockedServicesArray{"foo"}
-				rbs = &model.BlockedServicesArray{"foo"}
-			})
-			It("should have no changes", func() {
-				cl.EXPECT().BlockedServices().Return(rbs, nil)
-				err := actionBlockedServices(ac)
-				Ω(err).ShouldNot(HaveOccurred())
-			})
-			It("should have blockedServices changes", func() {
-				ac.origin.blockedServices = &model.BlockedServicesArray{"bar"}
-
-				cl.EXPECT().BlockedServices().Return(rbs, nil)
-				cl.EXPECT().SetBlockedServices(ac.origin.blockedServices)
-				err := actionBlockedServices(ac)
-				Ω(err).ShouldNot(HaveOccurred())
-			})
-		})
 		Context("actionBlockedServicesSchedule", func() {
 			var rbss *model.BlockedServicesSchedule
 			BeforeEach(func() {
@@ -599,7 +579,6 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().SafeSearchConfig().Return(&model.SafeSearchConfig{}, nil)
 				cl.EXPECT().SafeBrowsing()
 				cl.EXPECT().RewriteList().Return(&model.RewriteEntries{}, nil)
-				cl.EXPECT().BlockedServices()
 				cl.EXPECT().BlockedServicesSchedule()
 				cl.EXPECT().Filtering().Return(&model.FilterStatus{}, nil)
 				cl.EXPECT().Clients().Return(&model.Clients{}, nil)
@@ -622,7 +601,6 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().AddRewriteEntries()
 				cl.EXPECT().DeleteRewriteEntries()
 				cl.EXPECT().Filtering().Return(&model.FilterStatus{}, nil)
-				cl.EXPECT().BlockedServices()
 				cl.EXPECT().BlockedServicesSchedule()
 				cl.EXPECT().Clients().Return(&model.Clients{}, nil)
 				cl.EXPECT().AccessList().Return(&model.AccessList{}, nil)
@@ -641,7 +619,6 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().SafeSearchConfig().Return(&model.SafeSearchConfig{}, nil)
 				cl.EXPECT().SafeBrowsing()
 				cl.EXPECT().RewriteList().Return(&model.RewriteEntries{}, nil)
-				cl.EXPECT().BlockedServices()
 				cl.EXPECT().BlockedServicesSchedule()
 				cl.EXPECT().Filtering().Return(&model.FilterStatus{}, nil)
 				cl.EXPECT().Clients().Return(&model.Clients{}, nil)
@@ -663,7 +640,6 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().AddRewriteEntries()
 				cl.EXPECT().DeleteRewriteEntries()
 				cl.EXPECT().Filtering().Return(&model.FilterStatus{}, nil)
-				cl.EXPECT().BlockedServices()
 				cl.EXPECT().BlockedServicesSchedule()
 				cl.EXPECT().Clients().Return(&model.Clients{}, nil)
 				cl.EXPECT().AccessList().Return(&model.AccessList{}, nil)
@@ -685,7 +661,6 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().SafeSearchConfig().Return(&model.SafeSearchConfig{}, nil)
 				cl.EXPECT().SafeBrowsing()
 				cl.EXPECT().RewriteList().Return(&model.RewriteEntries{}, nil)
-				cl.EXPECT().BlockedServices()
 				cl.EXPECT().BlockedServicesSchedule()
 				cl.EXPECT().Filtering().Return(&model.FilterStatus{}, nil)
 				cl.EXPECT().Clients().Return(&model.Clients{}, nil)

--- a/testdata/querylog_config.json
+++ b/testdata/querylog_config.json
@@ -1,0 +1,8 @@
+{
+  "enabled": true,
+  "interval": 90,
+  "anonymize_client_ip": false,
+  "ignored": [
+    "foo.bar"
+  ]
+}

--- a/testdata/querylog_info.json
+++ b/testdata/querylog_info.json
@@ -1,5 +1,0 @@
-{
-  "enabled": true,
-  "interval": 90,
-  "anonymize_client_ip": false
-}


### PR DESCRIPTION
fixes #324 by extending QueryLogConfig with missing `Ignores property`