### PR TITLE
handle empty client blockes service schedule in equals check

### DIFF
--- a/pkg/client/model/model_test.go
+++ b/pkg/client/model/model_test.go
@@ -303,6 +303,23 @@ var _ = Describe("Types", func() {
 			})
 		})
 	})
+
+	Context("Client", func() {
+		Context("Equals", func() {
+			var (
+				cl1 *model.Client
+				cl2 *model.Client
+			)
+			BeforeEach(func() {
+				cl1 = &model.Client{Name: utils.Ptr("foo"), BlockedServicesSchedule: &model.Schedule{TimeZone: utils.Ptr("UTC")}}
+				cl2 = &model.Client{Name: utils.Ptr("foo"), BlockedServicesSchedule: &model.Schedule{TimeZone: utils.Ptr("Local")}}
+			})
+
+			It("should equal if only timezone differs on empty blocked service schedule", func() {
+				Ω(cl1.Equals(cl2)).Should(BeTrue())
+			})
+		})
+	})
 	Context("BlockedServices", func() {
 		Context("Equals", func() {
 			It("should be equal", func() {


### PR DESCRIPTION
the change seems to be an issue of adguard home when handling with empty BlockedServicesSchedule configs.
This change ignores the timezone on these configs if they are otherwise empty.

fixes #338