### PR TITLE
docs: add "Run as Linux Service via Systemd" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ WantedBy = multi-user.target
 
 ```
 
-Create a configuration file `/opt/adguardhome-sync/adguardhome-sync.yaml`, please follow "Config file" section below for details.
+Create a configuration file `/opt/adguardhome-sync/adguardhome-sync.yaml`, please follow [Config file](#config-file-1) section below for details.
 
 Install and enable service:
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,47 @@ adguardhome-sync run
 adguardhome-sync run --cron "0 */2 * * *"
 ```
 
+### Run as Linux Service via Systemd
+
+Assume you have downloaded the the `adguardhome-sync` binary to `/opt/adguardhome-sync`. 
+
+Create systemd service file `/opt/adguardhome-sync/adguardhome-sync.service`:
+
+```
+[Unit]
+Description = AdGuardHome Sync
+After = network.target
+
+[Service]
+ExecStart = /opt/adguardhome-sync/adguardhome-sync --config /opt/adguardhome-sync/adguardhome-sync.yaml run
+
+[Install]
+WantedBy = multi-user.target
+
+```
+
+Create a configuration file `/opt/adguardhome-sync/adguardhome-sync.yaml`, please follow "Config file" section below for details.
+
+Install and enable service:
+
+```bash
+sudo cp /opt/adguardhome-sync/adguardhome-sync.service /etc/systemd/system/
+
+sudo systemctl enable adguardhome-sync.service
+
+sudo systemctl start adguardhome-sync.service
+
+```
+
+Then you can check the status:
+
+```bash
+sudo systemctl status adguardhome-sync.service
+
+```
+
+If web UI has been enabled in configuration (default port is 8080), can also check the status via http://<server-IP>:8080
+
 ## Run Windows
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ adguardhome-sync run --cron "0 */2 * * *"
 
 ### Run as Linux Service via Systemd
 
+> Verified on Ubuntu Linux 24.04
+
 Assume you have downloaded the the `adguardhome-sync` binary to `/opt/adguardhome-sync`. 
 
 Create systemd service file `/opt/adguardhome-sync/adguardhome-sync.service`:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ sudo systemctl status adguardhome-sync.service
 
 ```
 
-If web UI has been enabled in configuration (default port is 8080), can also check the status via http://<server-IP>:8080
+If web UI has been enabled in configuration (default port is 8080), can also check the status via `http://<server-IP>:8080`
 
 ## Run Windows
 


### PR DESCRIPTION
I have recently added `addguardhome-sync` daemon as a service via systemd. 

Thought it would be helpful to have a section in README for others to refer to.