### PR TITLE
feat: implement sync metrics

### DIFF
--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -13,9 +13,9 @@ var _ = Describe("Metrics", func() {
 	BeforeEach(func() {
 		stats = make(OverallStats)
 	})
-	Context("Update / getStats", func() {
+	Context("UpdateInstances / getStats", func() {
 		It("generate correct stats", func() {
-			Update(InstanceMetricsList{[]InstanceMetrics{
+			UpdateInstances(InstanceMetricsList{[]InstanceMetrics{
 				{HostName: "foo", Status: &model.ServerStatus{}, Stats: &model.Stats{
 					NumDnsQueries: ptr.To(100),
 					DnsQueries: ptr.To(
@@ -74,7 +74,7 @@ var _ = Describe("Metrics", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 		It("should provide correct results with faked values", func() {
-			Update(metrics)
+			UpdateInstances(metrics)
 
 			_, dns, blocked, malware, adult := StatsGraph()
 

--- a/pkg/sync/scrape.go
+++ b/pkg/sync/scrape.go
@@ -32,7 +32,7 @@ func (w *worker) scrape() {
 	for _, replica := range w.cfg.Replicas {
 		iml.Metrics = append(iml.Metrics, w.getMetrics(replica))
 	}
-	metrics.Update(iml)
+	metrics.UpdateInstances(iml)
 }
 
 func (w *worker) getMetrics(inst types.AdGuardInstance) metrics.InstanceMetrics {

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -599,7 +599,7 @@ var _ = Describe("Sync", func() {
 			})
 			It("should have no changes", func() {
 				// origin
-				cl.EXPECT().Host()
+				cl.EXPECT().Host().Times(2)
 				cl.EXPECT().Status().Return(&model.ServerStatus{Version: versions.MinAgh}, nil)
 				cl.EXPECT().ProfileInfo().Return(&model.ProfileInfo{}, nil)
 				cl.EXPECT().Parental()
@@ -639,7 +639,7 @@ var _ = Describe("Sync", func() {
 				w.cfg.Features.DHCP.ServerConfig = false
 				w.cfg.Features.DHCP.StaticLeases = false
 				// origin
-				cl.EXPECT().Host()
+				cl.EXPECT().Host().Times(2)
 				cl.EXPECT().Status().Return(&model.ServerStatus{Version: versions.MinAgh}, nil)
 				cl.EXPECT().ProfileInfo().Return(&model.ProfileInfo{}, nil)
 				cl.EXPECT().Parental()
@@ -698,7 +698,7 @@ var _ = Describe("Sync", func() {
 				cl.EXPECT().DhcpConfig().Return(&model.DhcpStatus{}, nil)
 
 				// replica
-				cl.EXPECT().Host()
+				cl.EXPECT().Host().Times(2)
 				cl.EXPECT().Status().Return(&model.ServerStatus{Version: "v0.106.9"}, nil)
 				w.sync()
 			})


### PR DESCRIPTION
implements: #559

Sample metrics:
```
# HELP adguard_home_sync_sync_duration_seconds This represents the duration of the last sync in seconds
# TYPE adguard_home_sync_sync_duration_seconds gauge
adguard_home_sync_sync_duration_seconds{hostname="127.0.0.1:9091"} 4.688462667
adguard_home_sync_sync_duration_seconds{hostname="127.0.0.1:9093"} 11.886160655
# HELP adguard_home_sync_sync_successful This represents the whether the last sync was successful
# TYPE adguard_home_sync_sync_successful gauge
adguard_home_sync_sync_successful{hostname="127.0.0.1:9091"} 1
adguard_home_sync_sync_successful{hostname="127.0.0.1:9093"} 1
```
