### PR TITLE
Docs: Clarify initial setup instructions for origin and replicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ go install github.com/bakito/adguardhome-sync@latest
 
 ## Prerequisites
 
-Both the origin instance and replica(s) must be initially setup with AdguardHome via the AdguardHome installation wizard.
+Both the origin instance and replica(s) must be initially set up with AdguardHome via the AdguardHome installation wizard.
 
 ## Username / Password vs. Cookie
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ go install github.com/bakito/adguardhome-sync@latest
 
 ## Prerequisites
 
-Both the origin instance must be initially setup via the AdguardHome installation wizard.
+Both the origin instance and replica(s) must be initially setup with AdguardHome via the AdguardHome installation wizard.
 
 ## Username / Password vs. Cookie
 


### PR DESCRIPTION
## Description

This pull request clarifies an ambiguous sentence in the documentation regarding the initial setup process.

## The Ambiguity

The previous instruction was worded as:
https://github.com/bakito/adguardhome-sync/blob/92129ab0690162a43d080cfd7f4096cf56980546/README.md?plain=1#L46

This created ambiguity because:

1. The use of `Both` was grammatically incorrect with the singular `instance,` making it unclear what two components were being referred to.
2. It used the noun `setup` instead of the correct verb phrase `set up.`

## The Fix

This change rewrites the sentence to be grammatically correct and explicit. It clarifies that **both the origin instance and the replica(s)** require initial configuration. It also corrects the verb form to `set up.`

### The Correction
```
Both the origin instance and replica(s) must be initially set up with AdguardHome via the AdguardHome installation wizard.
```
