### PR TITLE
feat: add unauthorized health check based on status (if all success = http OK)

### DIFF
--- a/pkg/sync/http.go
+++ b/pkg/sync/http.go
@@ -105,6 +105,7 @@ func (w *worker) listenAndServe() {
 	r := gin.New()
 	r.Use(gin.Recovery())
 
+	r.HEAD("/healthz", w.handleHealthz)
 	r.GET("/healthz", w.handleHealthz)
 
 	if w.cfg.API.Username != "" && w.cfg.API.Password != "" {

--- a/pkg/sync/http.go
+++ b/pkg/sync/http.go
@@ -87,6 +87,10 @@ func (w *worker) handleStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, w.status())
 }
 
+func (w *worker) handleHealthz(c *gin.Context) {
+	c.Status(w.healthz())
+}
+
 func (w *worker) listenAndServe() {
 	sl := l.With("port", w.cfg.API.Port)
 	if w.cfg.API.TLS.Enabled() {
@@ -100,9 +104,37 @@ func (w *worker) listenAndServe() {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
 	r.Use(gin.Recovery())
+
+	r.GET("/healthz", w.handleHealthz)
+
 	if w.cfg.API.Username != "" && w.cfg.API.Password != "" {
-		r.Use(gin.BasicAuth(map[string]string{w.cfg.API.Username: w.cfg.API.Password}))
+		authorized := r.Group("/", gin.BasicAuth(map[string]string{w.cfg.API.Username: w.cfg.API.Password}))
+		authorized.POST("/api/v1/sync", w.handleSync)
+		authorized.GET("/api/v1/logs", w.handleLogs)
+		authorized.POST("/api/v1/clear-logs", w.handleClearLogs)
+		authorized.GET("/favicon.ico", w.handleFavicon)
+		authorized.GET("/", w.handleRoot)
+		authorized.GET("/api/v1/status", w.handleStatus)
+
+		if w.cfg.API.Metrics.Enabled {
+			authorized.GET("/metrics", metrics.Handler())
+	
+			go w.startScraping()
+		}
+	}else{
+		r.POST("/api/v1/sync", w.handleSync)
+		r.GET("/api/v1/logs", w.handleLogs)
+		r.POST("/api/v1/clear-logs", w.handleClearLogs)
+		r.GET("/api/v1/status", w.handleStatus)
+		r.GET("/favicon.ico", w.handleFavicon)
+		r.GET("/", w.handleRoot)
+		if w.cfg.API.Metrics.Enabled {
+			r.GET("/metrics", metrics.Handler())
+	
+			go w.startScraping()
+		}
 	}
+
 	httpServer := &http.Server{
 		Addr:              fmt.Sprintf(":%d", w.cfg.API.Port),
 		Handler:           r,
@@ -111,17 +143,6 @@ func (w *worker) listenAndServe() {
 	}
 
 	r.SetHTMLTemplate(template.Must(template.New("index.html").Parse(string(index))))
-	r.POST("/api/v1/sync", w.handleSync)
-	r.GET("/api/v1/logs", w.handleLogs)
-	r.POST("/api/v1/clear-logs", w.handleClearLogs)
-	r.GET("/api/v1/status", w.handleStatus)
-	r.GET("/favicon.ico", w.handleFavicon)
-	r.GET("/", w.handleRoot)
-	if w.cfg.API.Metrics.Enabled {
-		r.GET("/metrics", metrics.Handler())
-
-		go w.startScraping()
-	}
 
 	go func() {
 		var err error

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"sort"
 	"time"
+	"regexp"
 
 	"github.com/robfig/cron/v3"
 	"go.uber.org/zap"
@@ -20,7 +21,10 @@ import (
 	"github.com/bakito/adguardhome-sync/version"
 )
 
-var l = log.GetLogger("sync")
+var (
+	l = log.GetLogger("sync")
+	fixVersionCompareRegExp = regexp.MustCompile(`[^0-9\.]`)
+)
 
 // Sync config from origin to replica.
 func Sync(cfg *types.Config) error {
@@ -308,6 +312,9 @@ func (w *worker) syncTo(l *zap.SugaredLogger, o *origin, replica types.AdGuardIn
 		withError = true
 		return
 	}
+
+	replicaStatus.Version = fixVersionCompareRegExp.ReplaceAllString(replicaStatus.Version, "")
+	o.status.Version = fixVersionCompareRegExp.ReplaceAllString(o.status.Version, "")
 
 	rl.With("version", replicaStatus.Version).Info("Connected to replica")
 

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -120,6 +120,22 @@ func (w *worker) status() *syncStatus {
 	return syncStatus
 }
 
+func (w *worker) healthz() int {
+	status := w.status()
+
+	if status.Origin.Status != "success" {
+		return 503
+	}
+
+	for _, replica := range status.Replicas {
+		if replica.Status != "success" {
+			return 503
+		}
+	}
+
+	return 200
+}
+
 func (w *worker) getStatus(inst types.AdGuardInstance) replicaStatus {
 	st := replicaStatus{Host: inst.WebHost, URL: inst.WebURL}
 

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	l = log.GetLogger("sync")
-	fixVersionCompareRegExp = regexp.MustCompile(`[^0-9\.]`)
+	fixVersionCompareRegExp = regexp.MustCompile(`[^0-9.]`)
 )
 
 // Sync config from origin to replica.


### PR DESCRIPTION
I’ve changed the authorization of the API and added a /healthz endpoint that will respond with HTTP 200 if all replicas and origin are in state “success” or with 503 if they don’t. This endpoint is not authenticated.