### PR TITLE
Add OpenBSD support to releaser.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
       - linux
       - windows
       - darwin
+      - openbsd
     goarch:
       - 386
       - amd64
@@ -28,6 +29,10 @@ builds:
         goarch: arm
       - goos: windows
         goarch: arm64
+      - goos: openbsd
+        goarch: 386
+      - goos: openbsd
+        goarch: arm
     hooks:
       post:
         # don't upx windows binaries as they make trouble with virus scanners

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,7 @@ builds:
     hooks:
       post:
         # don't upx windows binaries as they make trouble with virus scanners
-        - bash -c 'if [[ "{{ .Path }}" != *.exe ]] && [[ "{{ .Path }}" != *darwin* ]]; then upx {{ .Path }}; fi'
+        - bash -c 'if [[ "{{ .Path }}" != *.exe ]] && [[ "{{ .Path }}" != *darwin* ]] && [[ "{{ .Path }}" != *openbsd* ]]; then upx {{ .Path }}; fi'
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
I've been using AdGuardHome sync on OpenBSD for some time, but the current release is limited to Go 1.24.1. In order to get the latest version of AdGuardHome sync, it's easiest to just build a release for OpenBSD.