### PR TITLE
feat: implement workaround for #633

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,8 @@ deepcopy-gen: tb.controller-gen
 	@touch ./tmp/deepcopy-gen-boilerplate.go.txt
 	$(TB_CONTROLLER_GEN) paths=./pkg/types object
 
-fmt: tb.golines tb.gofumpt
-	$(TB_GOLINES) --base-formatter="$(TB_GOFUMPT)" --max-len=120 --write-output .
-
 # Run tests
-test: generate fmt lint test-ci
+test: generate lint test-ci
 
 fuzz:
 	 go test -fuzz=FuzzMask -v ./pkg/types/ -fuzztime=60s

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -22,6 +22,19 @@ import (
 
 const envRedirectPolicyNoOfRedirects = "REDIRECT_POLICY_NO_OF_REDIRECTS"
 
+type Error struct {
+	message   string
+	errorCode int
+}
+
+func (e *Error) Error() string {
+	return e.message
+}
+
+func (e *Error) Code() int {
+	return e.errorCode
+}
+
 var (
 	l = log.GetLogger("client")
 	// ErrSetupNeeded custom error.
@@ -36,7 +49,10 @@ func detailedError(resp *resty.Response, err error) error {
 	if err != nil {
 		e += ": " + err.Error()
 	}
-	return errors.New(e)
+	return &Error{
+		message:   e,
+		errorCode: resp.StatusCode(),
+	}
 }
 
 // New create a new client.


### PR DESCRIPTION
Implement a workaround for #633

If `CONTINUE_ON_ERROR=true` and the profile request returns 401, the process continues